### PR TITLE
Leave readme-ifcfg-rh.txt untouched

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,12 +27,19 @@ class nm (
   Class['nm::install']
   -> Class['nm::service']
 
+  $_ignore = $facts['os']['release']['major'] ? {
+    '7'      => undef,
+    '8'      => undef,
+    default => 'readme-ifcfg-rh.txt',
+  }
+
   # remove ifcfg-* files to prevent conflicts between ifcfg- and .nmconnection
   file { '/etc/sysconfig/network-scripts':
     ensure  => 'directory',
     purge   => true,
     recurse => true,
     force   => true,
+    ignore  => $_ignore,
   }
 
   # remove any conflicting nm drop-in config files

--- a/spec/acceptance/nm_spec.rb
+++ b/spec/acceptance/nm_spec.rb
@@ -12,6 +12,15 @@ describe 'nm class' do
       it { is_expected.to be_installed }
     end
 
+    describe file('/etc/sysconfig/network-scripts/readme-ifcfg-rh.txt') do
+      case fact('os.release.major')
+      when '7', '8'
+        it { is_expected.not_to be file }
+      else
+        it { is_expected.to be_file }
+      end
+    end
+
     describe file('/etc/NetworkManager/NetworkManager.conf') do
       it { is_expected.to be_file }
       it { is_expected.to be_owned_by 'root' }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,6 +21,13 @@ describe 'nm' do
           )
         end
 
+        case facts[:os]['release']['major']
+        when '7', '8'
+          it { is_expected.to contain_file('/etc/sysconfig/network-scripts').without_ignore }
+        else
+          it { is_expected.to contain_file('/etc/sysconfig/network-scripts').with_ignore('readme-ifcfg-rh.txt') }
+        end
+
         it do
           is_expected.to contain_file('/etc/NetworkManager/conf.d').with(
             ensure: 'directory',


### PR DESCRIPTION
On EL9 there is a file

`/etc/sysconfig/network-scripts/readme-ifcfg-rh.txt`

This file contains useful information and will no longer be purged following this patch.

This will also stop a pointless puppet action when the NetworkManager upgrades.