### PR TITLE
Restart NetworkManager if config file has changed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,11 +25,8 @@ class nm (
   $conf_d_dir= "${conf_dir}/conf.d"
   $conn_dir = "${conf_dir}/system-connections"
 
-  require nm::install
-  require nm::service
-
-  Class['nm::install']
-  -> Class['nm::service']
+  include nm::install
+  include nm::service
 
   $_ignore = $facts['os']['release']['major'] ? {
     '7'      => undef,
@@ -67,6 +64,7 @@ class nm (
     ensure  => 'file',
     mode    => '0644',
     content => $_real_conf,
+    notify  => Service['NetworkManager'],
   }
 
   # remove unmanaged .nmconnection files

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,11 +25,8 @@ class nm (
   $conf_d_dir= "${conf_dir}/conf.d"
   $conn_dir = "${conf_dir}/system-connections"
 
-  require nm::install
-  require nm::service
-
-  Class['nm::install']
-  -> Class['nm::service']
+  include nm::install
+  include nm::service
 
   $_ignore = $facts['os']['release']['major'] ? {
     '7'      => undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,8 +25,11 @@ class nm (
   $conf_d_dir= "${conf_dir}/conf.d"
   $conn_dir = "${conf_dir}/system-connections"
 
-  include nm::install
-  include nm::service
+  require nm::install
+  require nm::service
+
+  Class['nm::install']
+  -> Class['nm::service']
 
   $_ignore = $facts['os']['release']['major'] ? {
     '7'      => undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,5 +2,7 @@
 class nm::install {
   assert_private()
 
-  ensure_packages(['NetworkManager'])
+  package { 'NetworkManager':
+    ensure => present,
+  }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,5 @@
 class nm::install {
   assert_private()
 
-  package { 'NetworkManager':
-    ensure => present,
-  }
+  ensure_packages(['NetworkManager'])
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,5 +5,6 @@ class nm::service {
   Service { 'NetworkManager':
     ensure => 'running',
     enable => true,
+    require => Package['NetworkManager'],
   }
 }

--- a/spec/acceptance/nm_spec.rb
+++ b/spec/acceptance/nm_spec.rb
@@ -52,6 +52,7 @@ describe 'nm class' do
       it { is_expected.to be_owned_by 'root' }
       it { is_expected.to be_grouped_into 'root' }
       it { is_expected.to be_mode '644' } # serverspec does not like a leading 0
+      it { is_expected.to contain_notify 'Service[NetworkManager]' }
 
       its(:content) do
         is_expected.to match <<~CONTENT

--- a/spec/acceptance/nm_spec.rb
+++ b/spec/acceptance/nm_spec.rb
@@ -52,7 +52,7 @@ describe 'nm class' do
       it { is_expected.to be_owned_by 'root' }
       it { is_expected.to be_grouped_into 'root' }
       it { is_expected.to be_mode '644' } # serverspec does not like a leading 0
-      it { is_expected.to contain_notify 'Service[NetworkManager]' }
+      it { is_expected.that_notifies 'Service[NetworkManager]' }
 
       its(:content) do
         is_expected.to match <<~CONTENT


### PR DESCRIPTION
If NetworkManager.conf is changed, the service isn't restarted. This PR aims to solve the problem.