### PR TITLE
Update deprecated ensure_packages in install

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,5 +2,5 @@
 class nm::install {
   assert_private()
 
-  ensure_packages(['NetworkManager'])
+  stdlib::ensure_packages(['NetworkManager'])
 }


### PR DESCRIPTION
This function is deprecated, please use stdlib::ensure_packages instead.

[https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/ensure_packages.rb](https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/functions/ensure_packages.rb)
